### PR TITLE
Enclose output path within single quotes (darwin)

### DIFF
--- a/capture/darwin.js
+++ b/capture/darwin.js
@@ -35,22 +35,32 @@ module.exports = function(options, callback) {
 	}
 
 	function capture(output, callback) {
-		var cmd = "screencapture"
-		+ " -t " + path.extname(output).toLowerCase().substring(1) // will create PNG by default
-		+ " -x '" + output + "'";
+		var cmd = "screencapture";
+		var args = [
+			// will create PNG by default
+			"-t",
+			path.extname(output).toLowerCase().substring(1),
+			"-x",
+			output
+		];
 
-		childProcess.exec(cmd, function(error, stdout, stderr) {
-			if(error)
-				callback(error, null);
-			else {
-				try {
-					fs.statSync(output);
-					callback(null, true);
-				}
-				catch (error) {
-					callback(error, null);
-				}
+		var captureChild = childProcess.spawn(cmd, args);
+
+		captureChild.on('close', (error) => {
+			if (error) {
+				callback(error);
+			} else {
+				callback();
 			}
+		});
+
+		captureChild.stdout.on('data', (data) => {
+			//console.log(`stdout: ${data}`);
+		});
+
+		captureChild.stderr.on('data', (data) => {
+			console.log(`stderr: ${data}`);
+			callback(data);
 		});
 	}
 };

--- a/capture/darwin.js
+++ b/capture/darwin.js
@@ -37,7 +37,7 @@ module.exports = function(options, callback) {
 	function capture(output, callback) {
 		var cmd = "screencapture"
 		+ " -t " + path.extname(output).toLowerCase().substring(1) // will create PNG by default
-		+ " -x " + output;
+		+ " -x '" + output + "'";
 
 		childProcess.exec(cmd, function(error, stdout, stderr) {
 			if(error)


### PR DESCRIPTION
This allows the usage of paths with spaces and other special characters. I bumped into this bug when trying to save a screenshot in a directory within `~/Library/Application Support/`
